### PR TITLE
Smooth scroll experience when scrolling upwards.

### DIFF
--- a/packages/infinite-scroll/src/js/infinite-scroll.js
+++ b/packages/infinite-scroll/src/js/infinite-scroll.js
@@ -426,7 +426,7 @@
         // for infinite scroll, if there are pages upwards then never allow it to be at the zero position so the up button can be active
         if (scrollTop === 0 && grid.infiniteScroll.scrollUp) {
           // using pixels results in a relative scroll, hence we have to use percentage
-          scrollEvent.y = {percentage: 1/scrollHeight};
+          scrollEvent.y = {pixels: 1};
         }
         else {
           scrollEvent.y = {percentage: scrollTop/scrollHeight};


### PR DESCRIPTION
Hi there, I've been struggling with infinite-scroll upwards since last two days.

Whenever I am trying to scroll upwards, the scroll is very flickery(jumpy) and jumps to previous pages even when I am not scrolling.
I found out a plunkr today which I tried, and the scrolling seems to work.
http://plnkr.co/edit/DfXkANDYkBOmjauF1HmF?p=preview <= jumpy scroll. Inconsistent behaviour
http://plnkr.co/edit/33b8FAHHfNO0ryQ9oSD4?p=preview <= smooth scroll experience.

what the guy has does is that, he has removed the line
scrollEvent.y = {percentage: 1/scrollHeight} with
scrollEvent.y = {pixels: 1};
And that fixes the issue.
Can anyone from the team check this and let me know if it is a bug which gets fixed by making this change.